### PR TITLE
$oj-name changed to $oj_name

### DIFF
--- a/uoj/1/app/controllers/forgot_pw.php
+++ b/uoj/1/app/controllers/forgot_pw.php
@@ -19,17 +19,17 @@
 		$user = $vdata['user'];
 		$password = $user["password"];
 		
-		$oj-name = UOJConfig::$data['profile']['oj-name'];
-		$oj-name-short = UOJConfig::$data['profile']['oj-name-short'];
+		$oj_name = UOJConfig::$data['profile']['oj-name'];
+		$oj_name-short = UOJConfig::$data['profile']['oj-name-short'];
 		$sufs = base64url_encode($user['username'] . "." . md5($user['username'] . "+" . $password));
 		$url = HTML::url("/reset-password", array('params' => array('p' => $sufs)));
 		$html = <<<EOD
 <base target="_blank" />
 
 <p>{$user['username']}您好，</p>
-<p>您刚刚启用了{$oj-name-short}密码找回功能，请进入下面的链接重设您的密码：</p>
+<p>您刚刚启用了{$oj_name-short}密码找回功能，请进入下面的链接重设您的密码：</p>
 <p><a href="$url">$url</a></p>
-<p>{$oj-name}</p>
+<p>{$oj_name}</p>
 
 <style type="text/css">
 body{font-size:14px;font-family:arial,verdana,sans-serif;line-height:1.666;padding:0;margin:0;overflow:auto;white-space:normal;word-wrap:break-word;min-height:100px}
@@ -39,7 +39,7 @@ EOD;
 		
 		$mailer = UOJMail::noreply();
 		$mailer->addAddress($user['email'], $user['username']);
-		$mailer->Subject = $oj-name-short."密码找回";
+		$mailer->Subject = $oj_name-short."密码找回";
 		$mailer->msgHTML($html);
 		if (!$mailer->send()) {  
 			error_log($mailer->ErrorInfo);

--- a/uoj/1/app/controllers/problem_data_manage.php
+++ b/uoj/1/app/controllers/problem_data_manage.php
@@ -11,7 +11,7 @@
 		become403Page();
 	}
 	
-	$oj-name = UOJConfig::$data['profile']['oj-name'];
+	$oj_name = UOJConfig::$data['profile']['oj-name'];
 	$problem_extra_config = getProblemExtraConfig($problem);
 
 	if (isset($_POST['getsvn'])) {
@@ -21,7 +21,7 @@
 
 <p>{$myUser['username']}您好，</p>
 <p>您的svn密码是：{$myUser['svn_password']}</p>
-<p>{$oj-name}</p>
+<p>{$oj_name}</p>
 
 <style type="text/css">
 body{font-size:14px;font-family:arial,verdana,sans-serif;line-height:1.666;padding:0;margin:0;overflow:auto;white-space:normal;word-wrap:break-word;min-height:100px}


### PR DESCRIPTION
$oj-name make problem manager 500
it will make forgot_pw 500 too
error log as below
[Thu Apr 06 18:40:31.972657 2017] [:error] [pid 797] [client 192.168.6.190:49725] PHP Parse error:  syntax error, unexpected '=' in /var/svn/uoj/cur/uoj/1/app/controllers/problem_data_manage.php on line 14, referer: http://local_uoj.ac:8001/problem/1/manage/managers