### PR TITLE
Suppot show time_limit and memory_limit

### DIFF
--- a/install/bundle/app_uoj233.sql
+++ b/install/bundle/app_uoj233.sql
@@ -260,7 +260,9 @@ CREATE TABLE IF NOT EXISTS `problems` (
   `extra_config` varchar(500) NOT NULL DEFAULT '{"view_content_type":"ALL","view_details_type":"ALL"}',
   `zan` int(11) NOT NULL,
   `ac_num` int(11) NOT NULL DEFAULT '0',
-  `submit_num` int(11) NOT NULL DEFAULT '0'
+  `submit_num` int(11) NOT NULL DEFAULT '0',
+  `time_limit` int(11) DEFAULT NULL,
+  `memory_limit` int(11) DEFAULT NULL
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------

--- a/uoj/1/app/controllers/problem.php
+++ b/uoj/1/app/controllers/problem.php
@@ -229,6 +229,20 @@ $('#contest-countdown').countdown(<?= $contest['end_time']->getTimestamp() - UOJ
 <a role="button" class="btn btn-info pull-right" href="/problem/<?= $problem['id'] ?>/statistics"><span class="glyphicon glyphicon-stats"></span> <?= UOJLocale::get('problems::statistics') ?></a>
 <?php endif ?>
 
+<div class="row text-center">
+    <?php $limit = DB::selectFirst("select time_limit, memory_limit from problems where id = {$problem['id']}"); ?>
+    <?php if($limit['time_limit'] != null ): ?>
+	    <span class="label label-info" style="font-size:15px">Time Limit:&nbsp;<?=$limit['time_limit']?> s</span>
+	<?php else: ?>
+	    <span class="label label-info" style="font-size:15px">Time Limit:&nbsp;N/A</span>
+	<?php endif ?>
+    <?php if($limit['memory_limit'] != null ): ?>
+	    <span class="label label-info" style="font-size:15px">Memory Limit:&nbsp;<?=$limit['memory_limit']?> MB</span>
+	<?php else: ?>
+	    <span class="label label-info" style="font-size:15px">Memory Limit:&nbsp;N/A</span>
+	<?php endif ?>
+</div>
+
 <ul class="nav nav-tabs" role="tablist">
 	<li class="active"><a href="#tab-statement" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-book"></span> <?= UOJLocale::get('problems::statement') ?></a></li>
 	<li><a href="#tab-submit-answer" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-upload"></span> <?= UOJLocale::get('problems::submit') ?></a></li>

--- a/uoj/1/app/libs/uoj-svn-lib.php
+++ b/uoj/1/app/libs/uoj-svn-lib.php
@@ -317,6 +317,11 @@
 				
 				$zip_file->close();
 
+				$time_limit = $this->final_problem_conf['time_limit'];
+                $memory_limit = $this->final_problem_conf['memory_limit'];
+                DB::update("update problems set time_limit = {$time_limit} where id = {$id}");
+                DB::update("update problems set memory_limit = {$memory_limit} where id = {$id}");
+				
 				$orig_requirement = json_decode($this->problem['submission_requirement'], true);
 				if (!$orig_requirement) {
 					$esc_requirement = DB::escape(json_encode($this->requirement));


### PR DESCRIPTION
feat(problem information): Suppot show time_limit and memory_limit

<body>
It's not very convenient to write the time_limit and memory_limit in each problem. In addition, somtimes we may change the data but forget to change the description in the problem. So it seems a good thing to show the time_limit and memory_limit automatically.

After the update, the system will update the time_limit and memory_limit into the database in each svn sync.

<footer>
BREAKING CHANGE:the database has some changes.
If you want to update, you have to add two column into the table problems.
The columns are named time_limit and memory_limit, the type are both int(11) and the default are both NULL.
The new problem will show the time_limit and memory_limit automatically after svn sync, but if you want the old problem to show them, you need to sync again or it will show N/A.