### PR TITLE
Suppot show time_limit and memory_limit(without database)

### DIFF
--- a/uoj/1/app/controllers/problem.php
+++ b/uoj/1/app/controllers/problem.php
@@ -229,6 +229,24 @@ $('#contest-countdown').countdown(<?= $contest['end_time']->getTimestamp() - UOJ
 <a role="button" class="btn btn-info pull-right" href="/problem/<?= $problem['id'] ?>/statistics"><span class="glyphicon glyphicon-stats"></span> <?= UOJLocale::get('problems::statistics') ?></a>
 <?php endif ?>
 
+<?php
+    $limit = getUOJConf("/var/uoj_data/{$problem['id']}/problem.conf");
+    $time_limit = $limit['time_limit'];
+    $memory_limit = $limit['memory_limit'];
+?>
+<div class="row text-center">
+    <?php if($time_limit != null ): ?>
+	    <span class="label label-info" style="font-size:15px">Time Limit:&nbsp;<?=$time_limit?> s</span>
+	<?php else: ?>
+	    <span class="label label-info" style="font-size:15px">Time Limit:&nbsp;N/A</span>
+	<?php endif ?>
+    <?php if($memory_limit != null ): ?>
+	    <span class="label label-info" style="font-size:15px">Memory Limit:&nbsp;<?=$memory_limit?> MB</span>
+	<?php else: ?>
+	    <span class="label label-info" style="font-size:15px">Memory Limit:&nbsp;N/A</span>
+	<?php endif ?>
+</div>
+
 <ul class="nav nav-tabs" role="tablist">
 	<li class="active"><a href="#tab-statement" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-book"></span> <?= UOJLocale::get('problems::statement') ?></a></li>
 	<li><a href="#tab-submit-answer" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-upload"></span> <?= UOJLocale::get('problems::submit') ?></a></li>


### PR DESCRIPTION
feat(problem information): Suppot show time_limit and memory_limit

<body>
It's not very convenient to write the time_limit and memory_limit in each problem. In addition, somtimes we may change the data but forget to change the description in the problem. So it seems a good thing to show the time_limit and memory_limit automatically.
After the update, the system will get the time_limit and memory_limit from problem.conf automatically.
Compared with the last pull request, this pull need't use the database.
In addition, the problem that doesn't have any data will show: time_limit: N/A memory_limit: N/A