### PR TITLE
fix(blog): Fix incorrect blog links from writing page.

### DIFF
--- a/uoj/1/app/controllers/subdomain/blog/blog_write.php
+++ b/uoj/1/app/controllers/subdomain/blog/blog_write.php
@@ -55,20 +55,18 @@
 					deleteBlog($blog['id']);
 					insertBlog(array_merge($data, array('is_draft' => 0)));
 					$blog = array('id' => DB::insert_id(), 'tags' => array());
-					$ret['blog_write_url'] = "/blog/{$blog['id']}/write";
-					$ret['blog_url'] = "/blog/{$blog['id']}";
+					$ret['blog_write_url'] = HTML::blog_url(UOJContext::user()['username'], "/blog/{$blog['id']}/write");
+					$ret['blog_url'] = HTML::blog_url(UOJContext::user()['username'], "/blog/{$blog['id']}");
 				}
 			} else {
 				updateBlog($blog['id'], $data);
 			}
 		} else {
+			insertBlog(array_merge($data, array('is_draft' => $data['is_hidden'] ? 1 : 0)));
 			$blog = array('id' => DB::insert_id(), 'tags' => array());
-			if ($data['is_hidden']) {
-				insertBlog(array_merge($data, array('is_draft' => 1)));
-			} else {
-				insertBlog(array_merge($data, array('is_draft' => 0)));
-				$ret['blog_write_url'] = "/blog/{$blog['id']}/write";
-				$ret['blog_url'] = "/blog/{$blog['id']}";
+			if (!$data['is_hidden']) {
+				$ret['blog_write_url'] = HTML::blog_url(UOJContext::user()['username'], "/blog/{$blog['id']}/write");
+				$ret['blog_url'] = HTML::blog_url(UOJContext::user()['username'], "/blog/{$blog['id']}");
 			}
 		}
 		if ($data['tags'] !== $blog['tags']) {

--- a/uoj/1/app/controllers/subdomain/blog/slide_write.php
+++ b/uoj/1/app/controllers/subdomain/blog/slide_write.php
@@ -56,19 +56,15 @@
 					deleteBlog($blog['id']);
 					insertSlide(array_merge($data, array('is_draft' => 0)));
 					$blog = array('id' => DB::insert_id(), 'tags' => array());
-					$ret['blog_write_url'] = "/slide/{$blog['id']}/write";
-					$ret['blog_url'] = "/blog/{$blog['id']}";
+					$ret['blog_write_url'] = HTML::blog_url(UOJContext::user()['username'], "/slide/{$blog['id']}/write");
+					$ret['blog_url'] = HTML::blog_url(UOJContext::user()['username'], "/blog/{$blog['id']}");
 				}
 			} else {
 				updateBlog($blog['id'], $data);
 			}
 		} else {
+			insertSlide(array_merge($data, array('is_draft' => $data['is_hidden'] ? 1 : 0)));
 			$blog = array('id' => DB::insert_id(), 'tags' => array());
-			if ($data['is_hidden']) {
-				insertSlide(array_merge($data, array('is_draft' => 1)));
-			} else {
-				insertSlide(array_merge($data, array('is_draft' => 0)));
-			}
 		}
 		if ($data['tags'] !== $blog['tags']) {
 			DB::delete("delete from blogs_tags where blog_id = {$blog['id']}");


### PR DESCRIPTION
When a blogs was saved, only links of form "/blog/id/write" was
returned, ignoring username. Under a subdomain
("user.blog.site/blog/id/write") this is fine, but it does not work if
a subdomain is not used ("site/blog/id/write"). `HTML::blog_url` should
be called to return the links.

Also, DB::insert_id is called before actually inserting the blogs to get
the new blog's id. This sometimes return a 0, especially when the user
has just deleted a blog. DB::insert_id should be called after the
insert instead.