### PR TITLE
fix(UOJContext.php): fix the bug that "page expires" occurs when accessing by localhost

### DIFF
--- a/uoj/1/app/models/UOJContext.php
+++ b/uoj/1/app/models/UOJContext.php
@@ -67,7 +67,7 @@ class UOJContext {
 			$domain = UOJConfig::$data['web']['main']['host'];
 		}
 		$domain = array_shift(explode(':', $domain));
-		if (validateIP($domain)) {
+		if (validateIP($domain) || $domain === 'localhost') {
 			$domain = '';
 		} else {
 			$domain = '.'.$domain;


### PR DESCRIPTION
To support subdomain cookies, an extra "." is added to the domain when setting the cookies.
However, this strategy fails on "localhost", because browsers do not recognize ".localhost".
So I add a check for this so that "localhost" is used as the cookie domain in this case.