### PR TITLE
refactor: deprecate v8js and migrate to aux markdown service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
           - image_name: web
             context: .
             dockerfile: web/Dockerfile
+          - image_name: web-aux
+            context: web-aux
+            dockerfile: web-aux/Dockerfile
       fail-fast: false
 
     steps:

--- a/db/app_uoj233.sql
+++ b/db/app_uoj233.sql
@@ -444,6 +444,17 @@ LOCK TABLES `judger_info` WRITE;
 UNLOCK TABLES;
 
 --
+-- Table structure for table `meta`
+--
+
+CREATE TABLE `meta` (
+  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `value` json NOT NULL,
+  `updated_at` datetime NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
 -- Table structure for table `problems`
 --
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,14 @@ services:
       - SOCKET_PORT=2333
       - SOCKET_PASSWORD=_judger_socket_password_
 
+  uoj-web-aux:
+    image: ghcr.io/universaloj/uoj-web-aux:latest
+    build:
+      context: ./web-aux/
+      dockerfile: Dockerfile
+    container_name: uoj-web-aux
+    restart: always
+
   uoj-web:
     image: ghcr.io/universaloj/uoj-web:latest
     build:
@@ -49,6 +57,7 @@ services:
     depends_on:
       - uoj-db
       - uoj-judger
+      - uoj-web-aux
     volumes:
       - ./uoj_data/web/data:/var/uoj_data
       - ./uoj_data/web/storage:/opt/uoj/web/app/storage

--- a/web-aux/Dockerfile
+++ b/web-aux/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:lts-alpine
+LABEL org.opencontainers.image.source=https://github.com/UniversalOJ/UOJ-System
+LABEL org.opencontainers.image.description="UOJ Web Aux - Markdown Rendering Server"
+LABEL org.opencontainers.image.licenses=MIT
+
+WORKDIR /opt/uoj
+COPY package*.json .
+RUN npm install
+COPY . .
+
+ENV LANG=C.UTF-8 TZ=Asia/Shanghai
+EXPOSE 7513
+CMD ["npm", "start"]

--- a/web-aux/index.js
+++ b/web-aux/index.js
@@ -1,0 +1,58 @@
+const express = require('express')
+const uoj_marked = require('./uoj-marked.js')
+const slide_marked = require('./marked.js')
+const bodyParser = require('body-parser')
+
+slide_marked.setOptions({
+	getLangClass: function (lang) {
+		lang = lang.toLowerCase();
+		switch (lang) {
+			case 'c': return 'c'
+			case 'c++': return 'cpp'
+			case 'pascal': return 'pascal'
+			default: return lang
+		}
+	},
+	getElementClass: function (tok) {
+		switch (tok.type) {
+			case 'list_item_start':
+				return 'fragment'
+			case 'loose_item_start':
+				return 'fragment'
+			default:
+				return null
+		}
+	}
+})
+
+var app = express()
+app.use(bodyParser.text({ limit: '50mb' }))
+
+app.post('/render-md/uoj', function (req, res) {
+	req.setTimeout(25000, function () {
+		res.send('编译时间超出限制，问问管理员怎么回事？')
+	});
+	try {
+		out = uoj_marked(req.body)
+	} catch (e) {
+		out = '编译失败，请发给管理员看看！'
+	}
+	res.send(out)
+})
+
+app.post('/render-md/slide', function (req, res) {
+	req.setTimeout(25000, function () {
+		res.send('编译时间超出限制，问问管理员怎么回事？')
+	});
+	try {
+		out = slide_marked(req.body)
+	} catch (e) {
+		out = '编译失败，请发给管理员看看！'
+	}
+	res.send(out)
+})
+
+// 7513 is just a random number
+const server = app.listen('7513', () => {
+	console.log('Server is listening on port 7513')
+})

--- a/web-aux/marked.js
+++ b/web-aux/marked.js
@@ -1,0 +1,1093 @@
+/**
+ * marked - a markdown parser
+ * Copyright (c) 2011-2013, Christopher Jeffrey. (MIT Licensed)
+ * https://github.com/chjj/marked
+ */
+
+;(function() {
+
+/**
+ * Block-Level Grammar
+ */
+
+var block = {
+  newline: /^\n+/,
+  code: /^( {4}[^\n]+\n*)+/,
+  fences: noop,
+  hr: /^( *[-*_]){3,} *(?:\n+|$)/,
+  heading: /^ *(#{1,6}) *([^\n]+?) *#* *(?:\n+|$)/,
+  nptable: noop,
+  lheading: /^([^\n]+)\n *(=|-){3,} *\n*/,
+  blockquote: /^( *>[^\n]+(\n[^\n]+)*\n*)+/,
+  list: /^( *)(bull) [\s\S]+?(?:hr|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
+  html: /^ *(?:comment|closed|closing) *(?:\n{2,}|\s*$)/,
+  def: /^ *\[([^\]]+)\]: *<?([^\s>]+)>?(?: +["(]([^\n]+)[")])? *(?:\n+|$)/,
+  table: noop,
+  paragraph: /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def))+)\n*/,
+  text: /^[^\n]+/
+};
+
+block.bullet = /(?:[*+-]|\d+\.)/;
+block.item = /^( *)(bull) [^\n]*(?:\n(?!\1bull )[^\n]*)*/;
+block.item = replace(block.item, 'gm')
+  (/bull/g, block.bullet)
+  ();
+
+block.list = replace(block.list)
+  (/bull/g, block.bullet)
+  ('hr', /\n+(?=(?: *[-*_]){3,} *(?:\n+|$))/)
+  ();
+
+block._tag = '(?!(?:'
+  + 'a|em|strong|small|s|cite|q|dfn|abbr|data|time|code'
+  + '|var|samp|kbd|sub|sup|i|b|u|mark|ruby|rt|rp|bdi|bdo'
+  + '|span|br|wbr|ins|del|img)\\b)\\w+(?!:/|@)\\b';
+
+block.html = replace(block.html)
+  ('comment', /<!--[\s\S]*?-->/)
+  ('closed', /<(tag)[\s\S]+?<\/\1>/)
+  ('closing', /<tag(?:"[^"]*"|'[^']*'|[^'">])*?>/)
+  (/tag/g, block._tag)
+  ();
+
+block.paragraph = replace(block.paragraph)
+  ('hr', block.hr)
+  ('heading', block.heading)
+  ('lheading', block.lheading)
+  ('blockquote', block.blockquote)
+  ('tag', '<' + block._tag)
+  ('def', block.def)
+  ();
+
+/**
+ * Normal Block Grammar
+ */
+
+block.normal = merge({}, block);
+
+/**
+ * GFM Block Grammar
+ */
+
+block.gfm = merge({}, block.normal, {
+  fences: /^ *(`{3,}|~{3,}) *(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
+  paragraph: /^/
+});
+
+block.gfm.paragraph = replace(block.paragraph)
+  ('(?!', '(?!' + block.gfm.fences.source.replace('\\1', '\\2') + '|')
+  ();
+
+/**
+ * GFM + Tables Block Grammar
+ */
+
+block.tables = merge({}, block.gfm, {
+  nptable: /^ *(\S.*\|.*)\n *([-:]+ *\|[-| :]*)\n((?:.*\|.*(?:\n|$))*)\n*/,
+  table: /^ *\|(.+)\n *\|( *[-:]+[-| :]*)\n((?: *\|.*(?:\n|$))*)\n*/
+});
+
+/**
+ * Block Lexer
+ */
+
+function Lexer(options) {
+  this.tokens = [];
+  this.tokens.links = {};
+  this.options = options || marked.defaults;
+  this.rules = block.normal;
+
+  if (this.options.gfm) {
+    if (this.options.tables) {
+      this.rules = block.tables;
+    } else {
+      this.rules = block.gfm;
+    }
+  }
+}
+
+/**
+ * Expose Block Rules
+ */
+
+Lexer.rules = block;
+
+/**
+ * Static Lex Method
+ */
+
+Lexer.lex = function(src, options) {
+  var lexer = new Lexer(options);
+  return lexer.lex(src);
+};
+
+/**
+ * Preprocessing
+ */
+
+Lexer.prototype.lex = function(src) {
+  src = src
+    .replace(/\r\n|\r/g, '\n')
+    .replace(/\t/g, '    ')
+    .replace(/\u00a0/g, ' ')
+    .replace(/\u2424/g, '\n');
+
+  return this.token(src, true);
+};
+
+/**
+ * Lexing
+ */
+
+Lexer.prototype.token = function(src, top) {
+  var src = src.replace(/^ +$/gm, '')
+    , next
+    , loose
+    , cap
+    , bull
+    , b
+    , item
+    , space
+    , i
+    , l;
+
+  while (src) {
+    // newline
+    if (cap = this.rules.newline.exec(src)) {
+      src = src.substring(cap[0].length);
+      if (cap[0].length > 1) {
+        this.tokens.push({
+          type: 'space'
+        });
+      }
+    }
+
+    // code
+    if (cap = this.rules.code.exec(src)) {
+      src = src.substring(cap[0].length);
+      cap = cap[0].replace(/^ {4}/gm, '');
+      this.tokens.push({
+        type: 'code',
+        text: !this.options.pedantic
+          ? cap.replace(/\n+$/, '')
+          : cap
+      });
+      continue;
+    }
+
+    // fences (gfm)
+    if (cap = this.rules.fences.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'code',
+        lang: cap[2],
+        text: cap[3]
+      });
+      continue;
+    }
+
+    // heading
+    if (cap = this.rules.heading.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'heading',
+        depth: cap[1].length,
+        text: cap[2]
+      });
+      continue;
+    }
+
+    // table no leading pipe (gfm)
+    if (top && (cap = this.rules.nptable.exec(src))) {
+      src = src.substring(cap[0].length);
+
+      item = {
+        type: 'table',
+        header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
+        align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
+        cells: cap[3].replace(/\n$/, '').split('\n')
+      };
+
+      for (i = 0; i < item.align.length; i++) {
+        if (/^ *-+: *$/.test(item.align[i])) {
+          item.align[i] = 'right';
+        } else if (/^ *:-+: *$/.test(item.align[i])) {
+          item.align[i] = 'center';
+        } else if (/^ *:-+ *$/.test(item.align[i])) {
+          item.align[i] = 'left';
+        } else {
+          item.align[i] = null;
+        }
+      }
+
+      for (i = 0; i < item.cells.length; i++) {
+        item.cells[i] = item.cells[i].split(/ *\| */);
+      }
+
+      this.tokens.push(item);
+
+      continue;
+    }
+
+    // lheading
+    if (cap = this.rules.lheading.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'heading',
+        depth: cap[2] === '=' ? 1 : 2,
+        text: cap[1]
+      });
+      continue;
+    }
+
+    // hr
+    if (cap = this.rules.hr.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'hr'
+      });
+      continue;
+    }
+
+    // blockquote
+    if (cap = this.rules.blockquote.exec(src)) {
+      src = src.substring(cap[0].length);
+
+      this.tokens.push({
+        type: 'blockquote_start'
+      });
+
+      cap = cap[0].replace(/^ *> ?/gm, '');
+
+      // Pass `top` to keep the current
+      // "toplevel" state. This is exactly
+      // how markdown.pl works.
+      this.token(cap, top);
+
+      this.tokens.push({
+        type: 'blockquote_end'
+      });
+
+      continue;
+    }
+
+    // list
+    if (cap = this.rules.list.exec(src)) {
+      src = src.substring(cap[0].length);
+      bull = cap[2];
+
+      this.tokens.push({
+        type: 'list_start',
+        ordered: bull.length > 1
+      });
+
+      // Get each top-level item.
+      cap = cap[0].match(this.rules.item);
+
+      next = false;
+      l = cap.length;
+      i = 0;
+
+      for (; i < l; i++) {
+        item = cap[i];
+
+        // Remove the list item's bullet
+        // so it is seen as the next token.
+        space = item.length;
+        item = item.replace(/^ *([*+-]|\d+\.) +/, '');
+
+        // Outdent whatever the
+        // list item contains. Hacky.
+        if (~item.indexOf('\n ')) {
+          space -= item.length;
+          item = !this.options.pedantic
+            ? item.replace(new RegExp('^ {1,' + space + '}', 'gm'), '')
+            : item.replace(/^ {1,4}/gm, '');
+        }
+
+        // Determine whether the next list item belongs here.
+        // Backpedal if it does not belong in this list.
+        if (this.options.smartLists && i !== l - 1) {
+          b = block.bullet.exec(cap[i+1])[0];
+          if (bull !== b && !(bull.length > 1 && b.length > 1)) {
+            src = cap.slice(i + 1).join('\n') + src;
+            i = l - 1;
+          }
+        }
+
+        // Determine whether item is loose or not.
+        // Use: /(^|\n)(?! )[^\n]+\n\n(?!\s*$)/
+        // for discount behavior.
+        loose = next || /\n\n(?!\s*$)/.test(item);
+        if (i !== l - 1) {
+          next = item[item.length-1] === '\n';
+          if (!loose) loose = next;
+        }
+
+        this.tokens.push({
+          type: loose
+            ? 'loose_item_start'
+            : 'list_item_start'
+        });
+
+        // Recurse.
+        this.token(item, false);
+
+        this.tokens.push({
+          type: 'list_item_end'
+        });
+      }
+
+      this.tokens.push({
+        type: 'list_end'
+      });
+
+      continue;
+    }
+
+    // html
+    if (cap = this.rules.html.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: this.options.sanitize
+          ? 'paragraph'
+          : 'html',
+        pre: cap[1] === 'pre',
+        text: cap[0]
+      });
+      continue;
+    }
+
+    // def
+    if (top && (cap = this.rules.def.exec(src))) {
+      src = src.substring(cap[0].length);
+      this.tokens.links[cap[1].toLowerCase()] = {
+        href: cap[2],
+        title: cap[3]
+      };
+      continue;
+    }
+
+    // table (gfm)
+    if (top && (cap = this.rules.table.exec(src))) {
+      src = src.substring(cap[0].length);
+
+      item = {
+        type: 'table',
+        header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
+        align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
+        cells: cap[3].replace(/(?: *\| *)?\n$/, '').split('\n')
+      };
+
+      for (i = 0; i < item.align.length; i++) {
+        if (/^ *-+: *$/.test(item.align[i])) {
+          item.align[i] = 'right';
+        } else if (/^ *:-+: *$/.test(item.align[i])) {
+          item.align[i] = 'center';
+        } else if (/^ *:-+ *$/.test(item.align[i])) {
+          item.align[i] = 'left';
+        } else {
+          item.align[i] = null;
+        }
+      }
+
+      for (i = 0; i < item.cells.length; i++) {
+        item.cells[i] = item.cells[i]
+          .replace(/^ *\| *| *\| *$/g, '')
+          .split(/ *\| */);
+      }
+
+      this.tokens.push(item);
+
+      continue;
+    }
+
+    // top-level paragraph
+    if (top && (cap = this.rules.paragraph.exec(src))) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'paragraph',
+        text: cap[1][cap[1].length-1] === '\n'
+          ? cap[1].slice(0, -1)
+          : cap[1]
+      });
+      continue;
+    }
+
+    // text
+    if (cap = this.rules.text.exec(src)) {
+      // Top-level should never reach here.
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'text',
+        text: cap[0]
+      });
+      continue;
+    }
+
+    if (src) {
+      throw new
+        Error('Infinite loop on byte: ' + src.charCodeAt(0));
+    }
+  }
+
+  return this.tokens;
+};
+
+/**
+ * Inline-Level Grammar
+ */
+
+var inline = {
+  escape: /^\\([\\`*{}\[\]()#+\-.!_>\$])/,
+  autolink: /^<([^ >]+(@|:\/)[^ >]+)>/,
+  url: noop,
+  tag: /^<!--[\s\S]*?-->|^<\/?\w+(?:"[^"]*"|'[^']*'|[^'">])*?>/,
+  link: /^!?\[(inside)\]\(href\)/,
+  reflink: /^!?\[(inside)\]\s*\[([^\]]*)\]/,
+  nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
+  strong: /^\*\*([\s\S]+?)\*\*(?!\*)/,                            //      /^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,
+  em: /^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,  //      /^\b_((?:__|[\s\S])+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
+  code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
+  math: /^\$((?:[^\\]|\\\\|\\[^\\]+?)+?)\$|^\$\$((?:[^\\]|\\\\|\\[^\\]+?)+?)\$\$|^\\begin{[^}]+}((?:[^\\]|\\\\|\\[^\\]+?)+?)\\end{[^}]+}/,
+  br: /^ {2,}\n(?!\s*$)/,
+  del: noop,
+  text: /^[\s\S]+?(?=[\\<!\[_*`\$]| {2,}\n|$)/
+};
+
+inline._inside = /(?:\[[^\]]*\]|[^\]]|\](?=[^\[]*\]))*/;
+inline._href = /\s*<?([^\s]*?)>?(?:\s+['"]([\s\S]*?)['"])?\s*/;
+
+inline.link = replace(inline.link)
+  ('inside', inline._inside)
+  ('href', inline._href)
+  ();
+
+inline.reflink = replace(inline.reflink)
+  ('inside', inline._inside)
+  ();
+
+/**
+ * Normal Inline Grammar
+ */
+
+inline.normal = merge({}, inline);
+
+/**
+ * Pedantic Inline Grammar
+ */
+
+inline.pedantic = merge({}, inline.normal, {
+  strong: /^__(?=\S)([\s\S]*?\S)__(?!_)|^\*\*(?=\S)([\s\S]*?\S)\*\*(?!\*)/,
+  em: /^_(?=\S)([\s\S]*?\S)_(?!_)|^\*(?=\S)([\s\S]*?\S)\*(?!\*)/
+});
+
+/**
+ * GFM Inline Grammar
+ */
+
+inline.gfm = merge({}, inline.normal, {
+  escape: replace(inline.escape)('])', '~|])')(),
+  url: /^(https?:\/\/[^\s<]+[^<.,:;"')\]\s])/,
+  del: /^~~(?=\S)([\s\S]*?\S)~~/,
+  text: replace(inline.text)
+    (']|', '~]|')
+    ('|', '|https?://|')
+    ()
+});
+
+/**
+ * GFM + Line Breaks Inline Grammar
+ */
+
+inline.breaks = merge({}, inline.gfm, {
+  br: replace(inline.br)('{2,}', '*')(),
+  text: replace(inline.gfm.text)('{2,}', '*')()
+});
+
+/**
+ * Inline Lexer & Compiler
+ */
+
+function InlineLexer(links, options) {
+  this.options = options || marked.defaults;
+  this.links = links;
+  this.rules = inline.normal;
+
+  if (!this.links) {
+    throw new
+      Error('Tokens array requires a `links` property.');
+  }
+
+  if (this.options.gfm) {
+    if (this.options.breaks) {
+      this.rules = inline.breaks;
+    } else {
+      this.rules = inline.gfm;
+    }
+  } else if (this.options.pedantic) {
+    this.rules = inline.pedantic;
+  }
+}
+
+/**
+ * Expose Inline Rules
+ */
+
+InlineLexer.rules = inline;
+
+/**
+ * Static Lexing/Compiling Method
+ */
+
+InlineLexer.output = function(src, links, options) {
+  var inline = new InlineLexer(links, options);
+  return inline.output(src);
+};
+
+/**
+ * Lexing/Compiling
+ */
+
+InlineLexer.prototype.output = function(src) {
+  var out = ''
+    , link
+    , text
+    , href
+    , cap;
+
+  while (src) {
+    // escape
+    if (cap = this.rules.escape.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += cap[1];
+      continue;
+    }
+    
+    // math
+    if (cap = this.rules.math.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += cap[0];
+      continue;
+    }
+
+    // autolink
+    if (cap = this.rules.autolink.exec(src)) {
+      src = src.substring(cap[0].length);
+      if (cap[2] === '@') {
+        text = cap[1][6] === ':'
+          ? this.mangle(cap[1].substring(7))
+          : this.mangle(cap[1]);
+        href = this.mangle('mailto:') + text;
+      } else {
+        text = escape(cap[1]);
+        href = text;
+      }
+      out += '<a href="'
+        + href
+        + '">'
+        + text
+        + '</a>';
+      continue;
+    }
+
+    // url (gfm)
+    if (cap = this.rules.url.exec(src)) {
+      src = src.substring(cap[0].length);
+      text = escape(cap[1]);
+      href = text;
+      out += '<a href="'
+        + href
+        + '">'
+        + text
+        + '</a>';
+      continue;
+    }
+
+    // tag
+    if (cap = this.rules.tag.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += this.options.sanitize
+        ? escape(cap[0])
+        : cap[0];
+      continue;
+    }
+
+    // link
+    if (cap = this.rules.link.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += this.outputLink(cap, {
+        href: cap[2],
+        title: cap[3]
+      });
+      continue;
+    }
+
+    // reflink, nolink
+    if ((cap = this.rules.reflink.exec(src))
+        || (cap = this.rules.nolink.exec(src))) {
+      src = src.substring(cap[0].length);
+      link = (cap[2] || cap[1]).replace(/\s+/g, ' ');
+      link = this.links[link.toLowerCase()];
+      if (!link || !link.href) {
+        out += cap[0][0];
+        src = cap[0].substring(1) + src;
+        continue;
+      }
+      out += this.outputLink(cap, link);
+      continue;
+    }
+
+    // strong
+    if (cap = this.rules.strong.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += '<strong>'
+        + this.output(cap[2] || cap[1])
+        + '</strong>';
+      continue;
+    }
+
+    // em
+    if (cap = this.rules.em.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += '<em>'
+        + this.output(cap[2] || cap[1])
+        + '</em>';
+      continue;
+    }
+
+    // code
+    if (cap = this.rules.code.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += '<code>'
+        + escape(cap[2], true)
+        + '</code>';
+      continue;
+    }
+
+    // br
+    if (cap = this.rules.br.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += '<br>';
+      continue;
+    }
+
+    // del (gfm)
+    if (cap = this.rules.del.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += '<del>'
+        + this.output(cap[1])
+        + '</del>';
+      continue;
+    }
+
+    // text
+    if (cap = this.rules.text.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += escape(cap[0]);
+      continue;
+    }
+
+    if (src) {
+      throw new
+        Error('Infinite loop on byte: ' + src.charCodeAt(0));
+    }
+  }
+
+  return out;
+};
+
+/**
+ * Compile Link
+ */
+
+InlineLexer.prototype.outputLink = function(cap, link) {
+  if (cap[0][0] !== '!') {
+    return '<a href="'
+      + escape(link.href)
+      + '"'
+      + (link.title
+      ? ' title="'
+      + escape(link.title)
+      + '"'
+      : '')
+      + '>'
+      + this.output(cap[1])
+      + '</a>';
+  } else {
+    return '<img src="'
+      + escape(link.href)
+      + '" alt="'
+      + escape(cap[1])
+      + '"'
+      + (link.title
+      ? ' title="'
+      + escape(link.title)
+      + '"'
+      : '')
+      + '>';
+  }
+};
+
+/**
+ * Mangle Links
+ */
+
+InlineLexer.prototype.mangle = function(text) {
+  var out = ''
+    , l = text.length
+    , i = 0
+    , ch;
+
+  for (; i < l; i++) {
+    ch = text.charCodeAt(i);
+    if (Math.random() > 0.5) {
+      ch = 'x' + ch.toString(16);
+    }
+    out += '&#' + ch + ';';
+  }
+
+  return out;
+};
+
+/**
+ * Parsing & Compiling
+ */
+
+function Parser(options) {
+  this.tokens = [];
+  this.token = null;
+  this.options = options || marked.defaults;
+}
+
+/**
+ * Static Parse Method
+ */
+
+Parser.parse = function(src, options) {
+  var parser = new Parser(options);
+  return parser.parse(src);
+};
+
+/**
+ * Parse Loop
+ */
+
+Parser.prototype.parse = function(src) {
+  this.inline = new InlineLexer(src.links, this.options);
+  this.tokens = src.reverse();
+
+  var out = '';
+  while (this.next()) {
+    out += this.tok();
+  }
+
+  return out;
+};
+
+/**
+ * Next Token
+ */
+
+Parser.prototype.next = function() {
+  return this.token = this.tokens.pop();
+};
+
+/**
+ * Preview Next Token
+ */
+
+Parser.prototype.peek = function() {
+  return this.tokens[this.tokens.length-1] || 0;
+};
+
+/**
+ * Parse Text Tokens
+ */
+
+Parser.prototype.parseText = function() {
+  var body = this.token.text;
+
+  while (this.peek().type === 'text') {
+    body += '\n' + this.next().text;
+  }
+
+  return this.inline.output(body);
+};
+
+/**
+ * Parse Current Token
+ */
+
+Parser.prototype.tok = function() {
+  var tok_class = this.options.getElementClass == null ? null : this.options.getElementClass(this.token);
+  tok_class = tok_class == null ? '' : ' class="' + tok_class + '"';
+  switch (this.token.type) {
+    case 'space': {
+      return '';
+    }
+    case 'hr': {
+      return '<hr' + tok_class + '>\n';
+    }
+    case 'heading': {
+      return '<h'
+        + this.token.depth
+        + tok_class
+        + '>'
+        + this.inline.output(this.token.text)
+        + '</h'
+        + this.token.depth
+        + '>\n';
+    }
+    case 'code': {
+      if (this.options.highlight) {
+        var code = this.options.highlight(this.token.text, this.token.lang);
+        if (code != null && code !== this.token.text) {
+          this.token.escaped = true;
+          this.token.text = code;
+        }
+      }
+
+      if (!this.token.escaped) {
+        this.token.text = escape(this.token.text, true);
+      }
+
+      return '<pre><code'
+        + (this.options.getLangClass && this.token.lang != undefined
+        ? ' class="'
+        + escape(this.options.getLangClass(this.token.lang), true)
+        + '"'
+        : '')
+        + '>'
+        + this.token.text
+        + '</code></pre>\n';
+    }
+    case 'table': {
+      var body = ''
+        , heading
+        , i
+        , row
+        , cell
+        , j;
+
+      // header
+      body += '<thead>\n<tr>\n';
+      for (i = 0; i < this.token.header.length; i++) {
+        heading = this.inline.output(this.token.header[i]);
+        body += this.token.align[i]
+          ? '<th align="' + this.token.align[i] + '">' + heading + '</th>\n'
+          : '<th>' + heading + '</th>\n';
+      }
+      body += '</tr>\n</thead>\n';
+
+      // body
+      body += '<tbody>\n'
+      for (i = 0; i < this.token.cells.length; i++) {
+        row = this.token.cells[i];
+        body += '<tr>\n';
+        for (j = 0; j < row.length; j++) {
+          cell = this.inline.output(row[j]);
+          body += this.token.align[j]
+            ? '<td align="' + this.token.align[j] + '">' + cell + '</td>\n'
+            : '<td>' + cell + '</td>\n';
+        }
+        body += '</tr>\n';
+      }
+      body += '</tbody>\n';
+
+      return '<table' + tok_class + '>\n'
+        + body
+        + '</table>\n';
+    }
+    case 'blockquote_start': {
+      var body = '';
+
+      while (this.next().type !== 'blockquote_end') {
+        body += this.tok();
+      }
+
+      return '<blockquote' + tok_class + '>\n'
+        + body
+        + '</blockquote>\n';
+    }
+    case 'list_start': {
+      var type = this.token.ordered ? 'ol' : 'ul'
+        , body = '';
+
+      while (this.next().type !== 'list_end') {
+        body += this.tok();
+      }
+
+      return '<'
+        + type
+        + tok_class
+        + '>\n'
+        + body
+        + '</'
+        + type
+        + '>\n';
+    }
+    case 'list_item_start': {
+      var body = '';
+
+      while (this.next().type !== 'list_item_end') {
+        body += this.token.type === 'text'
+          ? this.parseText()
+          : this.tok();
+      }
+
+      return '<li' + tok_class + '>'
+        + body
+        + '</li>\n';
+    }
+    case 'loose_item_start': {
+      var body = '';
+
+      while (this.next().type !== 'list_item_end') {
+        body += this.tok();
+      }
+
+      return '<li' + tok_class + '>'
+        + body
+        + '</li>\n';
+    }
+    case 'html': {
+      return this.token.text;
+      /*return !this.token.pre && !this.options.pedantic
+        ? this.inline.output(this.token.text)
+        : this.token.text;*/
+    }
+    case 'paragraph': {
+      return '<p' + tok_class + '>'
+        + this.inline.output(this.token.text)
+        + '</p>\n';
+    }
+    case 'text': {
+      return '<p' + tok_class + '>'
+        + this.parseText()
+        + '</p>\n';
+    }
+  }
+};
+
+/**
+ * Helpers
+ */
+
+function escape(html, encode) {
+  return html
+    .replace(!encode ? /&(?!#?\w+;)/g : /&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function replace(regex, opt) {
+  regex = regex.source;
+  opt = opt || '';
+  return function self(name, val) {
+    if (!name) return new RegExp(regex, opt);
+    val = val.source || val;
+    val = val.replace(/(^|[^\[])\^/g, '$1');
+    regex = regex.replace(name, val);
+    return self;
+  };
+}
+
+function noop() {}
+noop.exec = noop;
+
+function merge(obj) {
+  var i = 1
+    , target
+    , key;
+
+  for (; i < arguments.length; i++) {
+    target = arguments[i];
+    for (key in target) {
+      if (Object.prototype.hasOwnProperty.call(target, key)) {
+        obj[key] = target[key];
+      }
+    }
+  }
+
+  return obj;
+}
+
+/**
+ * Marked
+ */
+
+function marked(src, opt) {
+  try {
+    if (opt) opt = merge({}, marked.defaults, opt);
+    return Parser.parse(Lexer.lex(src, opt), opt);
+  } catch (e) {
+    e.message += '\nPlease report this to https://github.com/chjj/marked.';
+    if ((opt || marked.defaults).silent) {
+      return '<p>An error occured:</p><pre>'
+        + escape(e.message + '', true)
+        + '</pre>';
+    }
+    throw e;
+  }
+}
+
+/**
+ * Options
+ */
+
+marked.options =
+marked.setOptions = function(opt) {
+  merge(marked.defaults, opt);
+  return marked;
+};
+
+marked.defaults = {
+  gfm: true,
+  tables: true,
+  breaks: false,
+  pedantic: false,
+  sanitize: false,
+  smartLists: false,
+  silent: false,
+  highlight: null,
+  getLangClass: function(lang) {
+		lang = lang.toLowerCase();
+		switch (lang) {
+			case 'c': return 'sh_c';
+			case 'c++': return 'sh_cpp';
+			case 'pascal': return 'sh_pascal';
+			default: return 'sh_' + lang;
+		}
+  },
+  getElementClass: null
+};
+
+/**
+ * Expose
+ */
+
+marked.Parser = Parser;
+marked.parser = Parser.parse;
+
+marked.Lexer = Lexer;
+marked.lexer = Lexer.lex;
+
+marked.InlineLexer = InlineLexer;
+marked.inlineLexer = InlineLexer.output;
+
+marked.parse = marked;
+
+if (typeof exports === 'object') {
+  module.exports = marked;
+} else if (typeof define === 'function' && define.amd) {
+  define(function() { return marked; });
+} else {
+  this.marked = marked;
+}
+
+}).call(function() {
+  return this || (typeof window !== 'undefined' ? window : global);
+}());

--- a/web-aux/package.json
+++ b/web-aux/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "uoj",
+  "version": "1.0.0",
+  "description": "",
+  "author": "vfleaking",
+  "license": "ISC",
+  "dependencies": {
+    "body-parser": "^1.20.0",
+    "express": "^4.18.1"
+  },
+  "scripts": {
+    "start": "node index.js"
+  }
+}

--- a/web-aux/uoj-marked.js
+++ b/web-aux/uoj-marked.js
@@ -1,0 +1,1195 @@
+/**
+ * Modified from marked - a markdown parser
+ * Copyright (c) 2011-2013, Christopher Jeffrey. (MIT Licensed)
+ * https://github.com/chjj/marked
+ */
+
+;(function() {
+
+/**
+ * Block-Level Grammar
+ */
+
+var block = {
+  newline: /^\n+/,
+  code: /^( {4}[^\n]+\n*)+/,
+  fences: noop,
+  hr: /^( *[-*_]){3,} *(?:\n+|$)/,
+  heading: /^ *(#{1,6}) *([^\n]+?) *#* *(?:\n+|$)/,
+  nptable: noop,
+  lheading: /^([^\n]+)\n *(=|-){3,} *\n*/,
+  blockquote: /^( *>[^\n]+(\n[^\n]+)*\n*)+/,
+  list: /^( *)(bull) [\s\S]+?(?:hr|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
+  html: /^ *(?:comment|closed|closing) *(?:\n{2,}|\s*$)/,
+  def: /^ *\[([^\]]+)\]: *<?([^\s>]+)>?(?: +["(]([^\n]+)[")])? *(?:\n+|$)/,
+  table: noop,
+  paragraph: /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def))+)\n*/,
+  text: /^[^\n]+/
+};
+
+block.bullet = /(?:[*+-]|\d+\.)/;
+block.item = /^( *)(bull) [^\n]*(?:\n(?!\1bull )[^\n]*)*/;
+block.item = replace(block.item, 'gm')
+  (/bull/g, block.bullet)
+  ();
+
+block.list = replace(block.list)
+  (/bull/g, block.bullet)
+  ('hr', /\n+(?=(?: *[-*_]){3,} *(?:\n+|$))/)
+  ();
+
+block._tag = '(?!(?:'
+  + 'a|em|strong|small|s|cite|q|dfn|abbr|data|time|code'
+  + '|var|samp|kbd|sub|sup|i|b|u|mark|ruby|rt|rp|bdi|bdo'
+  + '|span|br|wbr|ins|del|img)\\b)\\w+(?!:/|@)\\b';
+
+block.html = replace(block.html)
+  ('comment', /<!--[\s\S]*?-->/)
+  ('closed', /<(tag)[\s\S]+?<\/\1>/)
+  ('closing', /<tag(?:"[^"]*"|'[^']*'|[^'">])*?>/)
+  (/tag/g, block._tag)
+  ();
+
+block.paragraph = replace(block.paragraph)
+  ('hr', block.hr)
+  ('heading', block.heading)
+  ('lheading', block.lheading)
+  ('blockquote', block.blockquote)
+  ('tag', '<' + block._tag)
+  ('def', block.def)
+  ();
+
+/**
+ * Normal Block Grammar
+ */
+
+block.normal = merge({}, block);
+
+/**
+ * GFM Block Grammar
+ */
+
+block.gfm = merge({}, block.normal, {
+  fences: /^ *(`{3,}|~{3,}) *(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
+  paragraph: /^/
+});
+
+block.gfm.paragraph = replace(block.paragraph)
+  ('(?!', '(?!' + block.gfm.fences.source.replace('\\1', '\\2') + '|')
+  ();
+
+/**
+ * GFM + Tables Block Grammar
+ */
+
+block.tables = merge({}, block.gfm, {
+  nptable: /^ *(\S.*\|.*)\n *([-:]+ *\|[-| :]*)\n((?:.*\|.*(?:\n|$))*)\n*/,
+  table: /^ *\|(.+)\n *\|( *[-:]+[-| :]*)\n((?: *\|.*(?:\n|$))*)\n*/
+});
+
+/**
+ * Block Lexer
+ */
+
+function Lexer(options) {
+  this.tokens = [];
+  this.tokens.links = {};
+  this.options = options || marked.defaults;
+  this.rules = block.normal;
+
+  if (this.options.gfm) {
+    if (this.options.tables) {
+      this.rules = block.tables;
+    } else {
+      this.rules = block.gfm;
+    }
+  }
+}
+
+/**
+ * Expose Block Rules
+ */
+
+Lexer.rules = block;
+
+/**
+ * Static Lex Method
+ */
+
+Lexer.lex = function(src, options) {
+  var lexer = new Lexer(options);
+  return lexer.lex(src);
+};
+
+/**
+ * Preprocessing
+ */
+
+Lexer.prototype.lex = function(src) {
+  src = src
+    .replace(/\r\n|\r/g, '\n')
+    .replace(/\t/g, '    ')
+    .replace(/\u00a0/g, ' ')
+    .replace(/\u2424/g, '\n');
+
+  return this.token(src, true);
+};
+
+/**
+ * Lexing
+ */
+
+Lexer.prototype.token = function(src, top) {
+  var src = src.replace(/^ +$/gm, '')
+    , next
+    , loose
+    , cap
+    , bull
+    , b
+    , item
+    , space
+    , i
+    , l;
+
+  while (src) {
+    // newline
+    if (cap = this.rules.newline.exec(src)) {
+      src = src.substring(cap[0].length);
+      if (cap[0].length > 1) {
+        this.tokens.push({
+          type: 'space'
+        });
+      }
+    }
+
+    // code
+    if (cap = this.rules.code.exec(src)) {
+      src = src.substring(cap[0].length);
+      cap = cap[0].replace(/^ {4}/gm, '');
+      this.tokens.push({
+        type: 'code',
+        text: !this.options.pedantic
+          ? cap.replace(/\n+$/, '')
+          : cap
+      });
+      continue;
+    }
+
+    // fences (gfm)
+    if (cap = this.rules.fences.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'code',
+        lang: cap[2],
+        text: cap[3]
+      });
+      continue;
+    }
+
+    // heading
+    if (cap = this.rules.heading.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'heading',
+        depth: cap[1].length,
+        text: cap[2]
+      });
+      continue;
+    }
+
+    // table no leading pipe (gfm)
+    if (top && (cap = this.rules.nptable.exec(src))) {
+      src = src.substring(cap[0].length);
+
+      item = {
+        type: 'table',
+        header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
+        align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
+        cells: cap[3].replace(/\n$/, '').split('\n')
+      };
+
+      for (i = 0; i < item.align.length; i++) {
+        if (/^ *-+: *$/.test(item.align[i])) {
+          item.align[i] = 'right';
+        } else if (/^ *:-+: *$/.test(item.align[i])) {
+          item.align[i] = 'center';
+        } else if (/^ *:-+ *$/.test(item.align[i])) {
+          item.align[i] = 'left';
+        } else {
+          item.align[i] = null;
+        }
+      }
+
+      for (i = 0; i < item.cells.length; i++) {
+        item.cells[i] = item.cells[i].split(/ *\| */);
+      }
+
+      this.tokens.push(item);
+
+      continue;
+    }
+
+    // lheading
+    if (cap = this.rules.lheading.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'heading',
+        depth: cap[2] === '=' ? 1 : 2,
+        text: cap[1]
+      });
+      continue;
+    }
+
+    // hr
+    if (cap = this.rules.hr.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'hr'
+      });
+      continue;
+    }
+
+    // blockquote
+    if (cap = this.rules.blockquote.exec(src)) {
+      src = src.substring(cap[0].length);
+
+      this.tokens.push({
+        type: 'blockquote_start'
+      });
+
+      cap = cap[0].replace(/^ *> ?/gm, '');
+
+      // Pass `top` to keep the current
+      // "toplevel" state. This is exactly
+      // how markdown.pl works.
+      this.token(cap, top);
+
+      this.tokens.push({
+        type: 'blockquote_end'
+      });
+
+      continue;
+    }
+
+    // list
+    if (cap = this.rules.list.exec(src)) {
+      src = src.substring(cap[0].length);
+      bull = cap[2];
+
+      this.tokens.push({
+        type: 'list_start',
+        ordered: bull.length > 1
+      });
+
+      // Get each top-level item.
+      cap = cap[0].match(this.rules.item);
+
+      next = false;
+      l = cap.length;
+      i = 0;
+
+      for (; i < l; i++) {
+        item = cap[i];
+
+        // Remove the list item's bullet
+        // so it is seen as the next token.
+        space = item.length;
+        item = item.replace(/^ *([*+-]|\d+\.) +/, '');
+
+        // Outdent whatever the
+        // list item contains. Hacky.
+        if (~item.indexOf('\n ')) {
+          space -= item.length;
+          item = !this.options.pedantic
+            ? item.replace(new RegExp('^ {1,' + space + '}', 'gm'), '')
+            : item.replace(/^ {1,4}/gm, '');
+        }
+
+        // Determine whether the next list item belongs here.
+        // Backpedal if it does not belong in this list.
+        if (this.options.smartLists && i !== l - 1) {
+          b = block.bullet.exec(cap[i+1])[0];
+          if (bull !== b && !(bull.length > 1 && b.length > 1)) {
+            src = cap.slice(i + 1).join('\n') + src;
+            i = l - 1;
+          }
+        }
+
+        // Determine whether item is loose or not.
+        // Use: /(^|\n)(?! )[^\n]+\n\n(?!\s*$)/
+        // for discount behavior.
+        loose = next || /\n\n(?!\s*$)/.test(item);
+        if (i !== l - 1) {
+          next = item[item.length-1] === '\n';
+          if (!loose) loose = next;
+        }
+
+        this.tokens.push({
+          type: loose
+            ? 'loose_item_start'
+            : 'list_item_start'
+        });
+
+        // Recurse.
+        this.token(item, false);
+
+        this.tokens.push({
+          type: 'list_item_end'
+        });
+      }
+
+      this.tokens.push({
+        type: 'list_end'
+      });
+
+      continue;
+    }
+
+    // html
+    if (cap = this.rules.html.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: this.options.sanitize
+          ? 'paragraph'
+          : 'html',
+        pre: cap[1] === 'pre',
+        text: cap[0]
+      });
+      continue;
+    }
+
+    // def
+    if (top && (cap = this.rules.def.exec(src))) {
+      src = src.substring(cap[0].length);
+      this.tokens.links[cap[1].toLowerCase()] = {
+        href: cap[2],
+        title: cap[3],
+        rest: ''
+      };
+      continue;
+    }
+
+    // table (gfm)
+    if (top && (cap = this.rules.table.exec(src))) {
+      src = src.substring(cap[0].length);
+
+      item = {
+        type: 'table',
+        header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
+        align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
+        cells: cap[3].replace(/(?: *\| *)?\n$/, '').split('\n')
+      };
+
+      for (i = 0; i < item.align.length; i++) {
+        if (/^ *-+: *$/.test(item.align[i])) {
+          item.align[i] = 'right';
+        } else if (/^ *:-+: *$/.test(item.align[i])) {
+          item.align[i] = 'center';
+        } else if (/^ *:-+ *$/.test(item.align[i])) {
+          item.align[i] = 'left';
+        } else {
+          item.align[i] = null;
+        }
+      }
+
+      for (i = 0; i < item.cells.length; i++) {
+        item.cells[i] = item.cells[i]
+          .replace(/^ *\| *| *\| *$/g, '')
+          .split(/ *\| */);
+      }
+
+      this.tokens.push(item);
+
+      continue;
+    }
+
+    // top-level paragraph
+    if (top && (cap = this.rules.paragraph.exec(src))) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'paragraph',
+        text: cap[1][cap[1].length-1] === '\n'
+          ? cap[1].slice(0, -1)
+          : cap[1]
+      });
+      continue;
+    }
+
+    // text
+    if (cap = this.rules.text.exec(src)) {
+      // Top-level should never reach here.
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'text',
+        text: cap[0]
+      });
+      continue;
+    }
+
+    if (src) {
+      throw new
+        Error('Infinite loop on byte: ' + src.charCodeAt(0));
+    }
+  }
+
+  return this.tokens;
+};
+
+/**
+ * Inline-Level Grammar
+ */
+
+var inline = {
+  escape: /^\\([\\`*{}\[\]()#+\-.!_>\$])/,
+  autolink: /^<([^ >]+(@|:\/)[^ >]+)>/,
+  url: noop,
+  tag: /^<!--[\s\S]*?-->|^<\/?\w+(?:"[^"]*"|'[^']*'|[^'">])*?>/,
+  link: /^!?\[(inside)\]\(href\)/,
+  reflink: /^!?\[(inside)\]\s*\[([^\]]*)\]/,
+  nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
+  strong: /^\*\*([\s\S]+?)\*\*(?!\*)/,                            //      /^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,
+  em: /^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,  //      /^\b_((?:__|[\s\S])+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
+  code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
+  math: /^\$((?:[^\\]|\\\\|\\[^\\]+?)+?)\$|^\$\$((?:[^\\]|\\\\|\\[^\\]+?)+?)\$\$|^\\begin{[^}]+}((?:[^\\]|\\\\|\\[^\\]+?)+?)\\end{[^}]+}/,
+  br: /^ {2,}\n(?!\s*$)/,
+  del: noop,
+  text: /^[\s\S]+?(?=[\\<!\[_*`\$]| {2,}\n|$)/,
+  
+  property_num: /(?:^|\s)\.(w|h|rating)=(\d+)\s*$/,
+  property_bool: /(?:^|\s)\.(keep|left|right|center|inline)\s*$/
+};
+
+inline._inside = /(?:\[[^\]]*\]|[^\]]|\](?=[^\[]*\]))*/;
+inline._href = /\s*<?([^\s)]*?)>?(?:\s+['"]([^)]*?)['"])?(\s*(?:\s\.[\w=]+\s*)*)/;
+
+inline.link = replace(inline.link)
+  ('inside', inline._inside)
+  ('href', inline._href)
+  ();
+
+inline.reflink = replace(inline.reflink)
+  ('inside', inline._inside)
+  ();
+
+/**
+ * Normal Inline Grammar
+ */
+
+inline.normal = merge({}, inline);
+
+/**
+ * Pedantic Inline Grammar
+ */
+
+inline.pedantic = merge({}, inline.normal, {
+  strong: /^__(?=\S)([\s\S]*?\S)__(?!_)|^\*\*(?=\S)([\s\S]*?\S)\*\*(?!\*)/,
+  em: /^_(?=\S)([\s\S]*?\S)_(?!_)|^\*(?=\S)([\s\S]*?\S)\*(?!\*)/
+});
+
+/**
+ * GFM Inline Grammar
+ */
+
+inline.gfm = merge({}, inline.normal, {
+  escape: replace(inline.escape)('])', '~|])')(),
+  url: /^(https?:\/\/[^\s<]+[^<.,:;"')\]\s])/,
+  del: /^~~(?=\S)([\s\S]*?\S)~~/,
+  text: replace(inline.text)
+    (']|', '~]|')
+    ('|', '|https?://|')
+    ()
+});
+
+/**
+ * GFM + Line Breaks Inline Grammar
+ */
+
+inline.breaks = merge({}, inline.gfm, {
+  br: replace(inline.br)('{2,}', '*')(),
+  text: replace(inline.gfm.text)('{2,}', '*')()
+});
+
+/**
+ * Inline Lexer & Compiler
+ */
+
+function InlineLexer(links, options) {
+  this.options = options || marked.defaults;
+  this.links = links;
+  this.rules = inline.normal;
+
+  if (!this.links) {
+    throw new
+      Error('Tokens array requires a `links` property.');
+  }
+
+  if (this.options.gfm) {
+    if (this.options.breaks) {
+      this.rules = inline.breaks;
+    } else {
+      this.rules = inline.gfm;
+    }
+  } else if (this.options.pedantic) {
+    this.rules = inline.pedantic;
+  }
+}
+
+/**
+ * Expose Inline Rules
+ */
+
+InlineLexer.rules = inline;
+
+/**
+ * Static Lexing/Compiling Method
+ */
+
+InlineLexer.output = function(src, links, options) {
+  var inline = new InlineLexer(links, options);
+  return inline.output(src);
+};
+
+/**
+ * Lexing/Compiling
+ */
+
+InlineLexer.prototype.output = function(src) {
+  var out = ''
+    , link
+    , text
+    , href
+    , cap;
+
+  while (src) {
+    // escape
+    if (cap = this.rules.escape.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += cap[1];
+      continue;
+    }
+    
+    // math
+    if (cap = this.rules.math.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += cap[0];
+      continue;
+    }
+
+    // autolink
+    if (cap = this.rules.autolink.exec(src)) {
+      src = src.substring(cap[0].length);
+      if (cap[2] === '@') {
+        text = cap[1][6] === ':'
+          ? this.mangle(cap[1].substring(7))
+          : this.mangle(cap[1]);
+        href = this.mangle('mailto:') + text;
+      } else {
+        text = escape(cap[1]);
+        href = text;
+      }
+      out += '<a href="'
+        + href
+        + '">'
+        + text
+        + '</a>';
+      continue;
+    }
+
+    // url (gfm)
+    if (cap = this.rules.url.exec(src)) {
+      src = src.substring(cap[0].length);
+      text = escape(cap[1]);
+      href = text;
+      out += '<a href="'
+        + href
+        + '">'
+        + text
+        + '</a>';
+      continue;
+    }
+
+    // tag
+    if (cap = this.rules.tag.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += this.options.sanitize
+        ? escape(cap[0])
+        : cap[0];
+      continue;
+    }
+
+    // link
+    if (cap = this.rules.link.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += this.outputLink(cap, {
+        href: cap[2],
+        title: cap[3],
+        rest: cap[4]
+      });
+      continue;
+    }
+
+    // reflink, nolink
+    if ((cap = this.rules.reflink.exec(src))
+        || (cap = this.rules.nolink.exec(src))) {
+      src = src.substring(cap[0].length);
+      link = (cap[2] || cap[1]).replace(/\s+/g, ' ');
+      link = this.links[link.toLowerCase()];
+      if (!link || !link.href) {
+        out += cap[0][0];
+        src = cap[0].substring(1) + src;
+        continue;
+      }
+      out += this.outputLink(cap, link);
+      continue;
+    }
+
+    // strong
+    if (cap = this.rules.strong.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += '<strong>'
+        + this.output(cap[2] || cap[1])
+        + '</strong>';
+      continue;
+    }
+
+    // em
+    if (cap = this.rules.em.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += '<em>'
+        + this.output(cap[2] || cap[1])
+        + '</em>';
+      continue;
+    }
+
+    // code
+    if (cap = this.rules.code.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += '<code>'
+        + escape(cap[2], true)
+        + '</code>';
+      continue;
+    }
+
+    // br
+    if (cap = this.rules.br.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += '<br>';
+      continue;
+    }
+
+    // del (gfm)
+    if (cap = this.rules.del.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += '<del>'
+        + this.output(cap[1])
+        + '</del>';
+      continue;
+    }
+
+    // text
+    if (cap = this.rules.text.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += escape(cap[0]);
+      continue;
+    }
+
+    if (src) {
+      throw new
+        Error('Infinite loop on byte: ' + src.charCodeAt(0));
+    }
+  }
+
+  return out;
+};
+
+/**
+ * Compile Link
+ */
+
+InlineLexer.prototype.outputLink = function(cap, link) {
+  if (cap[0][0] !== '!') {
+    
+    if (link.href[0] == ':') {
+      var ret = this.extractProperties(link.rest);
+      if (link.href == ':user' && ret[1].rating !== undefined) {
+        return '<span class="uoj-username" data-rating="' + ret[1].rating + '">' + escape(cap[1]) + '</span>';
+      } else {
+        return '<span class="text-danger">{errors occur in processing ' + escape(link.href) + '}</span>';
+      }
+    }
+    
+    return '<a href="'
+      + escape(link.href)
+      + '"'
+      + (link.title
+      ? ' title="'
+      + escape(link.title)
+      + '"'
+      : '')
+      + '>'
+      + this.output(cap[1])
+      + '</a>';
+  } else {
+    var ret = this.extractProperties(link.rest)
+      , style = ''
+      , cls;
+    
+    if (ret[1].h !== undefined) {
+      style += "height:" + ret[1].h + "px;";
+    }
+    if (ret[1].w !== undefined) {
+      style += "width:" + ret[1].w + "px;";
+    }
+    if (ret[1].left) {
+      cls = 'img-responsive';
+    } else if (ret[1].right) {
+      cls = 'img-responsive';
+      style += "margin-left: auto;";
+    } else if (ret[1].inline) {
+      cls = '';
+    } else {
+      cls = 'img-responsive center-block';
+    }
+    
+    return '<img src="'
+      + escape(link.href)
+      + '" alt="'
+      + escape(cap[1])
+      + '"'
+      + (link.title ? ' title="' + escape(link.title) + '"' : '')
+      + (cls ? ' class="' + cls + '"' : '')
+      + (style ? ' style="' + style + '"' : '')
+      + '>';
+  }
+};
+
+/**
+ * Extract Properties
+ */
+
+InlineLexer.prototype.extractProperties = function(src) {
+  var props = {}
+    , cap;
+  
+  if (!src) {
+    return ['', props];
+  }
+  while (src) {
+    // width, height, rating
+    if (cap = this.rules.property_num.exec(src)) {
+      src = src.substring(0, src.length - cap[0].length);
+      if (!(cap[1] in props)) {
+        props[cap[1]] = cap[2];
+      }
+      continue;
+    }
+
+    // keep, left, right, center
+    if (cap = this.rules.property_bool.exec(src)) {
+      src = src.substring(0, src.length - cap[0].length);
+      props[cap[1]] = true;
+      continue;
+    }
+    
+    break;
+  }
+  
+  return [src, props];
+};
+
+/**
+ * Mangle Links
+ */
+
+InlineLexer.prototype.mangle = function(text) {
+  var out = ''
+    , l = text.length
+    , i = 0
+    , ch;
+
+  for (; i < l; i++) {
+    ch = text.charCodeAt(i);
+    if (Math.random() > 0.5) {
+      ch = 'x' + ch.toString(16);
+    }
+    out += '&#' + ch + ';';
+  }
+
+  return out;
+};
+
+/**
+ * Parsing & Compiling
+ */
+
+function Parser(options) {
+  this.tokens = [];
+  this.token = null;
+  this.options = options || marked.defaults;
+}
+
+/**
+ * Static Parse Method
+ */
+
+Parser.parse = function(src, options) {
+  var parser = new Parser(options);
+  return parser.parse(src);
+};
+
+/**
+ * Parse Loop
+ */
+
+Parser.prototype.parse = function(src) {
+  this.inline = new InlineLexer(src.links, this.options);
+  this.tokens = src.reverse();
+
+  var out = '';
+  while (this.next()) {
+    out += this.tok();
+  }
+
+  return out;
+};
+
+/**
+ * Next Token
+ */
+
+Parser.prototype.next = function() {
+  return this.token = this.tokens.pop();
+};
+
+/**
+ * Preview Next Token
+ */
+
+Parser.prototype.peek = function() {
+  return this.tokens[this.tokens.length-1] || 0;
+};
+
+/**
+ * Parse Text Tokens
+ */
+
+Parser.prototype.parseText = function() {
+  var body = this.token.text;
+
+  while (this.peek().type === 'text') {
+    body += '\n' + this.next().text;
+  }
+
+  return this.inline.output(body);
+};
+
+/**
+ * Parse Current Token
+ */
+
+Parser.prototype.tok = function() {
+  var tok_class = this.options.getElementClass == null ? null : this.options.getElementClass(this.token);
+  tok_class = tok_class == null ? '' : ' class="' + tok_class + '"';
+  switch (this.token.type) {
+    case 'space': {
+      return '';
+    }
+    case 'hr': {
+      return '<hr' + tok_class + '>\n';
+    }
+    case 'heading': {
+      return '<h'
+        + this.token.depth
+        + tok_class
+        + '>'
+        + this.inline.output(this.token.text)
+        + '</h'
+        + this.token.depth
+        + '>\n';
+    }
+    case 'code': {
+      if (this.options.highlight) {
+        var code = this.options.highlight(this.token.text, this.token.lang);
+        if (code != null && code !== this.token.text) {
+          this.token.escaped = true;
+          this.token.text = code;
+        }
+      }
+
+      if (!this.token.escaped) {
+        this.token.text = escape(this.token.text, true);
+      }
+      
+      if (this.options.getLangClass && this.token.lang != undefined) {
+        return '<pre><code class="'
+        + escape(this.options.getLangClass(this.token.lang), true)
+        + '">'
+        + this.token.text
+        + '</code></pre>\n';
+      } else {
+        return '<pre>' + this.token.text + '</pre>';
+      }
+    }
+    case 'table': {
+      var body = ''
+        , heading
+        , i
+        , row
+        , cell
+        , attr
+        , j;
+
+      // header
+      body += '<thead>\n<tr>\n';
+      for (i = 0; i < this.token.header.length; i++) {
+        if (!this.token.header[i]) {
+          continue;
+        }
+        
+        heading = this.inline.extractProperties(this.token.header[i]);
+        heading[0] = this.inline.output(heading[0]);
+        attr = '';
+        if (this.token.align[i]) {
+          attr += ' style="text-align:' + this.token.align[i] + '"';
+        }
+        if (heading[1].w !== undefined) {
+          attr += ' colspan="' + cell[1].w + '"';
+        }
+        if (heading[1].h !== undefined) {
+          attr += ' rowspan="' + cell[1].h + '"';
+        }
+        body += '<th' + attr + '>' + heading[0] + '</th>\n';
+      }
+      body += '</tr>\n</thead>\n';
+
+      // body
+      body += '<tbody>\n'
+      for (i = 0; i < this.token.cells.length; i++) {
+        row = this.token.cells[i];
+        body += '<tr>\n';
+        for (j = 0; j < row.length; j++) {
+          if (!row[j]) {
+            continue;
+          }
+          
+          cell = this.inline.extractProperties(row[j]);
+          cell[0] = this.inline.output(cell[0]);
+          attr = '';
+          if (this.token.align[j]) {
+            attr += ' style="text-align:' + this.token.align[j] + '"';
+          }
+          if (cell[1].w !== undefined) {
+            attr += ' colspan="' + cell[1].w + '"';
+          }
+          if (cell[1].h !== undefined) {
+            attr += ' rowspan="' + cell[1].h + '"';
+          }
+          body += '<td' + attr + '>' + cell[0] + '</td>\n';
+        }
+        body += '</tr>\n';
+      }
+      body += '</tbody>\n';
+
+      return '<div class="table-responsive">\n' + '<table' + tok_class + '>\n'
+        + body
+        + '</table>\n</div>\n';
+    }
+    case 'blockquote_start': {
+      var body = '';
+
+      while (this.next().type !== 'blockquote_end') {
+        body += this.tok();
+      }
+
+      return '<blockquote' + tok_class + '>\n'
+        + body
+        + '</blockquote>\n';
+    }
+    case 'list_start': {
+      var type = this.token.ordered ? 'ol' : 'ul'
+        , body = '';
+
+      while (this.next().type !== 'list_end') {
+        body += this.tok();
+      }
+
+      return '<'
+        + type
+        + tok_class
+        + '>\n'
+        + body
+        + '</'
+        + type
+        + '>\n';
+    }
+    case 'list_item_start': {
+      var body = '';
+
+      while (this.next().type !== 'list_item_end') {
+        body += this.token.type === 'text'
+          ? this.parseText()
+          : this.tok();
+      }
+
+      return '<li' + tok_class + '>'
+        + body
+        + '</li>\n';
+    }
+    case 'loose_item_start': {
+      var body = '';
+
+      while (this.next().type !== 'list_item_end') {
+        body += this.tok();
+      }
+
+      return '<li' + tok_class + '>'
+        + body
+        + '</li>\n';
+    }
+    case 'html': {
+      return this.token.text;
+      /*return !this.token.pre && !this.options.pedantic
+        ? this.inline.output(this.token.text)
+        : this.token.text;*/
+    }
+    case 'paragraph': {
+      return '<p' + tok_class + '>'
+        + this.inline.output(this.token.text)
+        + '</p>\n';
+    }
+    case 'text': {
+      return '<p' + tok_class + '>'
+        + this.parseText()
+        + '</p>\n';
+    }
+  }
+};
+
+/**
+ * Helpers
+ */
+
+function escape(html, encode) {
+  return html
+    .replace(!encode ? /&(?!#?\w+;)/g : /&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function replace(regex, opt) {
+  regex = regex.source;
+  opt = opt || '';
+  return function self(name, val) {
+    if (!name) return new RegExp(regex, opt);
+    val = val.source || val;
+    val = val.replace(/(^|[^\[])\^/g, '$1');
+    regex = regex.replace(name, val);
+    return self;
+  };
+}
+
+function noop() {}
+noop.exec = noop;
+
+function merge(obj) {
+  var i = 1
+    , target
+    , key;
+
+  for (; i < arguments.length; i++) {
+    target = arguments[i];
+    for (key in target) {
+      if (Object.prototype.hasOwnProperty.call(target, key)) {
+        obj[key] = target[key];
+      }
+    }
+  }
+
+  return obj;
+}
+
+/**
+ * Marked
+ */
+
+function marked(src, opt) {
+  try {
+    if (opt) opt = merge({}, marked.defaults, opt);
+    return Parser.parse(Lexer.lex(src, opt), opt);
+  } catch (e) {
+    e.message += '\nPlease report this to https://github.com/chjj/marked.';
+    if ((opt || marked.defaults).silent) {
+      return '<p>An error occured:</p><pre>'
+        + escape(e.message + '', true)
+        + '</pre>';
+    }
+    throw e;
+  }
+}
+
+/**
+ * Options
+ */
+
+marked.options =
+marked.setOptions = function(opt) {
+  merge(marked.defaults, opt);
+  return marked;
+};
+
+marked.defaults = {
+  gfm: true,
+  tables: true,
+  breaks: false,
+  pedantic: false,
+  sanitize: false,
+  smartLists: false,
+  silent: false,
+  highlight: null,
+  getLangClass: function(lang) {
+    lang = lang.toLowerCase();
+    switch (lang) {
+      case 'c': return 'sh_c';
+      case 'c++': return 'sh_cpp';
+      case 'pascal': return 'sh_pascal';
+      default: return 'sh_' + lang;
+    }
+  },
+  getElementClass: function(token) {
+    switch (token.type) {
+      case 'table':
+        return 'table table-bordered table-text-center table-vertical-middle';
+      default:
+        return null;
+    }
+  }
+};
+
+/**
+ * Expose
+ */
+
+marked.Parser = Parser;
+marked.parser = Parser.parse;
+
+marked.Lexer = Lexer;
+marked.lexer = Lexer.lex;
+
+marked.InlineLexer = InlineLexer;
+marked.inlineLexer = InlineLexer.output;
+
+marked.parse = marked;
+
+if (typeof exports === 'object') {
+  module.exports = marked;
+} else if (typeof define === 'function' && define.amd) {
+  define(function() { return marked; });
+} else {
+  this.marked = marked;
+}
+
+}).call(function() {
+  return this || (typeof window !== 'undefined' ? window : global);
+}());

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,11 +8,8 @@ ARG CLONE_ADDFLAG
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN dpkg -s gnupg 2>/dev/null || (apt-get update && apt-get install -y gnupg) &&\
-echo "deb http://ppa.launchpad.net/stesie/libv8/ubuntu bionic main" | tee /etc/apt/sources.list.d/stesie-libv8.list && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D858A0DF &&\
-apt-get update && apt-get install -y git vim ntp zip unzip curl wget apache2 libapache2-mod-xsendfile libapache2-mod-php php php-dev php-pear php-zip php-mysql php-mbstring php-gd php-intl php-xsl g++ make re2c libv8-7.5-dev libyaml-dev &&\
-yes | pecl install yaml &&\
-git clone https://github.com/phpv8/v8js.git --depth=1 -b 2.1.2 /tmp/pear/download/v8js-master && cd /tmp/pear/download/v8js-master &&\
-phpize && ./configure --with-php-config=/usr/bin/php-config --with-v8js=/opt/libv8-7.5 && make install && cd -
+apt-get update && apt-get install -y git vim ntp zip unzip curl wget apache2 libapache2-mod-xsendfile libapache2-mod-php php php-dev php-pear php-zip php-mysql php-mbstring php-gd php-intl php-xsl g++ make re2c libyaml-dev &&\
+yes | pecl install yaml 
 
 ADD . /opt/uoj
 WORKDIR /opt/uoj

--- a/web/app/controllers/add_contest.php
+++ b/web/app/controllers/add_contest.php
@@ -34,7 +34,7 @@
 	$time_form->handle = function(&$vdata) {
 		$start_time_str = $vdata['start_time']->format('Y-m-d H:i:s');
 				
-		$purifier = HTML::pruifier();
+		$purifier = HTML::purifier();
 		
 		$esc_name = $_POST['name'];
 		$esc_name = $purifier->purify($esc_name);

--- a/web/app/controllers/contest_manage.php
+++ b/web/app/controllers/contest_manage.php
@@ -41,7 +41,7 @@
 		global $contest;
 		$start_time_str = $vdata['start_time']->format('Y-m-d H:i:s');
 		
-		$purifier = HTML::pruifier();
+		$purifier = HTML::purifier();
 		
 		$esc_name = $_POST['name'];
 		$esc_name = $purifier->purify($esc_name);

--- a/web/app/models/HTML.php
+++ b/web/app/models/HTML.php
@@ -146,7 +146,7 @@ class HTML {
 		return implode("&", $r);
 	}
 	
-	public static function pruifier() {
+	public static function purifier() {
 		include_once $_SERVER['DOCUMENT_ROOT'] . '/app/vendor/htmlpurifier/HTMLPurifier.auto.php';
 		$config = HTMLPurifier_Config::createDefault();
 		//$config->set('HTML.Doctype', 'HTML 4.01 Transitional');

--- a/web/app/models/UOJBlogEditor.php
+++ b/web/app/models/UOJBlogEditor.php
@@ -1,7 +1,6 @@
 <?php
 
 class UOJBlogEditor {
-
 	/**
 	 * @var string blog, slide, or quiz
 	 */
@@ -119,7 +118,7 @@ class UOJBlogEditor {
 				die(json_encode(array('content_md' => '不合法的 YAML 格式')));
 			}
 			
-			$marked = function($md) use($purifier) {
+			$marked = function($md) use ($purifier) {
 				$html = UOJMarkdown::compile_from_markdown($md, ['type' => 'slide']);
 				if ($html === false) {
 					die(json_encode(array('content_md' => '未知错误')));

--- a/web/app/models/UOJContext.php
+++ b/web/app/models/UOJContext.php
@@ -1,6 +1,23 @@
 <?php
 
 class UOJContext {
+	public static $meta_default = [
+		'active_duration_M' => 36,
+		'markdown' => [
+			'backend' => 'aux',
+			'aux_url' => 'http://uoj-web-aux:7513',
+			'timeout' => 30
+		],
+		'submission_frequency' => [
+			'interval' => 'PT1S',
+			'limit' => 1,
+		],
+		'update_judgement_status_delay' => [
+			'base' => 500,
+			'adder' => 500
+		],
+	];
+
 	public static $data = array();
 	
 	public static function pageConfig() {
@@ -116,6 +133,15 @@ class UOJContext {
 						return $blog['poster'] == self::$data['user']['username'] && $blog['type'] == 'S' && $blog['is_draft'] == false;
 				}
 				break;
+		}
+	}
+
+	public static function getMeta($name) {
+		$value = DB::selectFirst("select value from meta where name='$name'");
+		if ($value === null) {
+			return self::$meta_default[$name];
+		} else {
+			return json_decode($value['value'], true);
 		}
 	}
 }

--- a/web/app/models/UOJLog.php
+++ b/web/app/models/UOJLog.php
@@ -1,0 +1,37 @@
+<?php
+
+class UOJLog {
+	public static function error() {
+        $msg = '';
+        foreach (func_get_args() as $var) {
+            if ($msg !== '') {
+                $msg .= ', ';
+            }
+            if (!is_string($var)) {
+                $msg .= var_export($var, true);
+            } else {
+                $msg .= $var;
+            }
+        }
+        error_log('[uoj error] '.$msg);
+	}
+	
+	public static function warning() {
+        $msg = '';
+        foreach (func_get_args() as $var) {
+            if ($msg !== '') {
+                $msg .= ', ';
+            }
+            if (!is_string($var)) {
+                $msg .= var_export($var, true);
+            } else {
+                $msg .= $var;
+            }
+        }
+        error_log('[uoj warning] '.$msg);
+	}
+
+    public static function error_meta_val_not_set($name) {
+        UOJLog::error("$name is not set in the meta table");
+    }
+}

--- a/web/app/models/UOJLog.php
+++ b/web/app/models/UOJLog.php
@@ -2,36 +2,36 @@
 
 class UOJLog {
 	public static function error() {
-        $msg = '';
-        foreach (func_get_args() as $var) {
-            if ($msg !== '') {
-                $msg .= ', ';
-            }
-            if (!is_string($var)) {
-                $msg .= var_export($var, true);
-            } else {
-                $msg .= $var;
-            }
-        }
-        error_log('[uoj error] '.$msg);
+		$msg = '';
+		foreach (func_get_args() as $var) {
+			if ($msg !== '') {
+				$msg .= ', ';
+			}
+			if (!is_string($var)) {
+				$msg .= var_export($var, true);
+			} else {
+				$msg .= $var;
+			}
+		}
+		error_log('[uoj error] '.$msg);
 	}
 	
 	public static function warning() {
-        $msg = '';
-        foreach (func_get_args() as $var) {
-            if ($msg !== '') {
-                $msg .= ', ';
-            }
-            if (!is_string($var)) {
-                $msg .= var_export($var, true);
-            } else {
-                $msg .= $var;
-            }
-        }
-        error_log('[uoj warning] '.$msg);
+		$msg = '';
+		foreach (func_get_args() as $var) {
+			if ($msg !== '') {
+				$msg .= ', ';
+			}
+			if (!is_string($var)) {
+				$msg .= var_export($var, true);
+			} else {
+				$msg .= $var;
+			}
+		}
+		error_log('[uoj warning] '.$msg);
 	}
 
-    public static function error_meta_val_not_set($name) {
-        UOJLog::error("$name is not set in the meta table");
-    }
+	public static function error_meta_val_not_set($name) {
+		UOJLog::error("$name is not set in the meta table");
+	}
 }

--- a/web/app/models/UOJMarkdown.php
+++ b/web/app/models/UOJMarkdown.php
@@ -1,46 +1,45 @@
 <?php
 
 class UOJMarkdown {
+	public static $v8_uoj_marked = null;
+	public static $v8_slide_marked = null;
 
-    public static $v8_uoj_marked = null;
-    public static $v8_slide_marked = null;
-
-    public static $config = null;
+	public static $config = null;
 
 	public static function compile_from_markdown($md, $cfg = []) {
 		$cfg += [
 			'type' => 'uoj'
 		];
 
-        if (!isset(static::$config)) {
-            static::$config = UOJContext::getMeta('markdown');
-        }
+		if (!isset(static::$config)) {
+			static::$config = UOJContext::getMeta('markdown');
+		}
 
-        if (static::$config['backend'] == 'v8js') {
-            return static::compile_from_markdown_v8($md, $cfg);
-        } else {
-            return static::compile_from_markdown_aux($md, $cfg);
-        }
+		if (static::$config['backend'] == 'v8js') {
+			return static::compile_from_markdown_v8($md, $cfg);
+		} else {
+			return static::compile_from_markdown_aux($md, $cfg);
+		}
 	}
 
 	private static function compile_from_markdown_v8($md, $cfg) {
 		if ($cfg['type'] == 'uoj') {
-            if (!isset(static::$v8_uoj_marked)) {
-                try {
-                    static::$v8_uoj_marked = new V8Js('PHP');
-                    static::$v8_uoj_marked->executeString(file_get_contents(UOJContext::documentRoot().'/public/js/uoj-marked.js'), 'marked.js');
-                } catch (V8JsException $e) {
-                    static::$v8_uoj_marked = null;
-                    return false;
-                }
-            }
-            $v8 = static::$v8_uoj_marked;
+			if (!isset(static::$v8_uoj_marked)) {
+				try {
+					static::$v8_uoj_marked = new V8Js('PHP');
+					static::$v8_uoj_marked->executeString(file_get_contents(UOJContext::documentRoot().'/public/js/uoj-marked.js'), 'marked.js');
+				} catch (V8JsException $e) {
+					static::$v8_uoj_marked = null;
+					return false;
+				}
+			}
+			$v8 = static::$v8_uoj_marked;
 		} elseif ($cfg['type'] == 'slide') {
-            if (!isset(static::$v8_slide_marked)) {
-                try {
-                    static::$v8_slide_marked = new V8Js('PHP');
-                    static::$v8_slide_marked->executeString(file_get_contents(UOJContext::documentRoot().'/public/js/marked.js'), 'marked.js');
-                    static::$v8_slide_marked->executeString(<<<EOD
+			if (!isset(static::$v8_slide_marked)) {
+				try {
+					static::$v8_slide_marked = new V8Js('PHP');
+					static::$v8_slide_marked->executeString(file_get_contents(UOJContext::documentRoot().'/public/js/marked.js'), 'marked.js');
+					static::$v8_slide_marked->executeString(<<<EOD
                         marked.setOptions({
                             getLangClass: function(lang) {
                                 lang = lang.toLowerCase();
@@ -63,43 +62,43 @@ class UOJMarkdown {
                             }
                         })
                         EOD
-                    );
-                } catch (V8JsException $e) {
-                    static::$v8_slide_marked = null;
-                    return false;
-                }
-            }
-            $v8 = static::$v8_slide_marked;
+					);
+				} catch (V8JsException $e) {
+					static::$v8_slide_marked = null;
+					return false;
+				}
+			}
+			$v8 = static::$v8_slide_marked;
 		} else {
 			return false;
 		}
 
-        try {
-            $v8->md = $md;
-            return $v8->executeString('marked(PHP.md)');
-        } catch (V8JsException $e) {
-            return false;
-        }
-    }
+		try {
+			$v8->md = $md;
+			return $v8->executeString('marked(PHP.md)');
+		} catch (V8JsException $e) {
+			return false;
+		}
+	}
 
 	private static function compile_from_markdown_aux($md, $cfg) {
-        if (!isset(static::$config['timeout'])) {
-            UOJLog::error_meta_val_not_set('markdown.timeout');
-            return false;
-        }
+		if (!isset(static::$config['timeout'])) {
+			UOJLog::error_meta_val_not_set('markdown.timeout');
+			return false;
+		}
 
-        $option = [
-            'http' => [
-                'header' => [
-                    'Content-Type: text/plain',
-                    'Context-Length: ' . strlen($md)
-                ],
-                'method' => 'POST',
-                'content' => $md,
-                'timeout' => static::$config['timeout']
-            ]
-        ];
-        $context = stream_context_create($option);
+		$option = [
+		    'http' => [
+		        'header' => [
+		            'Content-Type: text/plain',
+		            'Context-Length: ' . strlen($md)
+		        ],
+		        'method' => 'POST',
+		        'content' => $md,
+		        'timeout' => static::$config['timeout']
+		    ]
+		];
+		$context = stream_context_create($option);
 		if ($cfg['type'] == 'uoj') {
 			$result = @file_get_contents(static::$config['aux_url']."/render-md/uoj", false, $context);
 			return $result;
@@ -109,5 +108,5 @@ class UOJMarkdown {
 		} else {
 			return false;
 		}
-    }
+	}
 }

--- a/web/app/models/UOJMarkdown.php
+++ b/web/app/models/UOJMarkdown.php
@@ -1,0 +1,113 @@
+<?php
+
+class UOJMarkdown {
+
+    public static $v8_uoj_marked = null;
+    public static $v8_slide_marked = null;
+
+    public static $config = null;
+
+	public static function compile_from_markdown($md, $cfg = []) {
+		$cfg += [
+			'type' => 'uoj'
+		];
+
+        if (!isset(static::$config)) {
+            static::$config = UOJContext::getMeta('markdown');
+        }
+
+        if (static::$config['backend'] == 'v8js') {
+            return static::compile_from_markdown_v8($md, $cfg);
+        } else {
+            return static::compile_from_markdown_aux($md, $cfg);
+        }
+	}
+
+	private static function compile_from_markdown_v8($md, $cfg) {
+		if ($cfg['type'] == 'uoj') {
+            if (!isset(static::$v8_uoj_marked)) {
+                try {
+                    static::$v8_uoj_marked = new V8Js('PHP');
+                    static::$v8_uoj_marked->executeString(file_get_contents(UOJContext::documentRoot().'/public/js/uoj-marked.js'), 'marked.js');
+                } catch (V8JsException $e) {
+                    static::$v8_uoj_marked = null;
+                    return false;
+                }
+            }
+            $v8 = static::$v8_uoj_marked;
+		} elseif ($cfg['type'] == 'slide') {
+            if (!isset(static::$v8_slide_marked)) {
+                try {
+                    static::$v8_slide_marked = new V8Js('PHP');
+                    static::$v8_slide_marked->executeString(file_get_contents(UOJContext::documentRoot().'/public/js/marked.js'), 'marked.js');
+                    static::$v8_slide_marked->executeString(<<<EOD
+                        marked.setOptions({
+                            getLangClass: function(lang) {
+                                lang = lang.toLowerCase();
+                                switch (lang) {
+                                    case 'c': return 'c';
+                                    case 'c++': return 'cpp';
+                                    case 'pascal': return 'pascal';
+                                    default: return lang;
+                                }
+                            },
+                            getElementClass: function(tok) {
+                                switch (tok.type) {
+                                    case 'list_item_start':
+                                        return 'fragment';
+                                    case 'loose_item_start':
+                                        return 'fragment';
+                                    default:
+                                        return null;
+                                }
+                            }
+                        })
+                        EOD
+                    );
+                } catch (V8JsException $e) {
+                    static::$v8_slide_marked = null;
+                    return false;
+                }
+            }
+            $v8 = static::$v8_slide_marked;
+		} else {
+			return false;
+		}
+
+        try {
+            $v8->md = $md;
+            return $v8->executeString('marked(PHP.md)');
+        } catch (V8JsException $e) {
+            return false;
+        }
+    }
+
+	private static function compile_from_markdown_aux($md, $cfg) {
+        if (!isset(static::$config['timeout'])) {
+            UOJLog::error_meta_val_not_set('markdown.timeout');
+            return false;
+        }
+
+        $option = [
+            'http' => [
+                'header' => [
+                    'Content-Type: text/plain',
+                    'Context-Length: ' . strlen($md)
+                ],
+                'method' => 'POST',
+                'content' => $md,
+                'timeout' => static::$config['timeout']
+            ]
+        ];
+        $context = stream_context_create($option);
+		if ($cfg['type'] == 'uoj') {
+			$result = @file_get_contents(static::$config['aux_url']."/render-md/uoj", false, $context);
+			return $result;
+		} elseif ($cfg['type'] == 'slide') {
+			$result = @file_get_contents(static::$config['aux_url']."/render-md/slide", false, $context);
+			return $result;
+		} else {
+			return false;
+		}
+    }
+}

--- a/web/install.sh
+++ b/web/install.sh
@@ -10,13 +10,9 @@ getAptPackage(){
     printf "\n\n==> Getting environment packages\n"
     # Update apt sources and install
     export DEBIAN_FRONTEND=noninteractive
-    dpkg -s gnupg 2>/dev/null || (apt-get update && apt-get install -y gnupg)
-    echo "deb http://ppa.launchpad.net/stesie/libv8/ubuntu bionic main" | tee /etc/apt/sources.list.d/stesie-libv8.list && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D858A0DF
-    apt-get update && apt-get install -y git vim ntp zip unzip curl wget apache2 libapache2-mod-xsendfile libapache2-mod-php php php-dev php-pear php-zip php-mysql php-mbstring php-gd php-intl php-xsl g++ make re2c libv8-7.5-dev libyaml-dev
+    apt-get update && apt-get install -y git vim ntp zip unzip curl wget apache2 libapache2-mod-xsendfile libapache2-mod-php php php-dev php-pear php-zip php-mysql php-mbstring php-gd php-intl php-xsl g++ make re2c libyaml-dev
     # Install PHP extensions
     yes | pecl install yaml
-    git clone https://github.com/phpv8/v8js.git --depth=1 -b 4c026f3fb291797c109adcabda6aeba6491fe44f /tmp/pear/download/v8js-master && cd /tmp/pear/download/v8js-master
-    phpize && ./configure --with-php-config=/usr/bin/php-config --with-v8js=/opt/libv8-7.5 && make install && cd -
 }
 
 setLAMPConf(){
@@ -45,7 +41,6 @@ UOJEOF
     a2enmod rewrite headers && sed -i -e '172s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
     #Create UOJ session save dir and make PHP extensions available
     mkdir --mode=733 /var/lib/php/uoj_sessions && chmod +t /var/lib/php/uoj_sessions
-    sed -i -e '912a\extension=v8js.so\nextension=yaml.so' /etc/php/7.4/apache2/php.ini
 	sed -i 's|;sys_temp_dir = "/tmp"|sys_temp_dir = "/tmp"|g' /etc/php/7.4/apache2/php.ini
 }
 

--- a/web/install.sh
+++ b/web/install.sh
@@ -41,6 +41,8 @@ UOJEOF
     a2enmod rewrite headers && sed -i -e '172s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
     #Create UOJ session save dir and make PHP extensions available
     mkdir --mode=733 /var/lib/php/uoj_sessions && chmod +t /var/lib/php/uoj_sessions
+    echo extension=yaml >/etc/php/7.4/mods-available/yaml.ini &&
+    ln -s /etc/php/7.4/mods-available/yaml.ini /etc/php/7.4/apache2/conf.d/20-yaml.ini
 	sed -i 's|;sys_temp_dir = "/tmp"|sys_temp_dir = "/tmp"|g' /etc/php/7.4/apache2/php.ini
 }
 


### PR DESCRIPTION
The [upstream](https://github.com/vfleaking/uoj) removed v8js and uses a [aux nodeJS server](https://github.com/vfleaking/uoj/blob/master/web/app/uoj-aux/index.js) to render markdown. 
This commit synced up partially with the [upstream changes](https://github.com/vfleaking/uoj/commit/04061436e53ac7390b34aac6760e03fc6ad6b39f). 

- [index.js](https://github.com/vfleaking/uoj/blob/master/web/app/uoj-aux/index.js)
- [uoj-marked.js](https://github.com/vfleaking/uoj/blob/master/web/public/js/uoj-marked.js)
- [UOJBlogEditor.php](https://github.com/vfleaking/uoj/blob/master/web/app/models/UOJBlogEditor.php)
- [UOJMarkdown.php](https://github.com/vfleaking/uoj/blob/master/web/app/models/UOJMarkdown.php)
